### PR TITLE
Improovements to the code. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,23 @@
 # Home Assistant Tesy integration
 
-The Tesy integration allows you to control a smart water heater.
+This Unofficial Tesy integration allows you to controll smart wifi devices based on external esp32 WiFi module (black pcb). 
+It won't work if you have older device based on Atheros AR9331 chipsed since the local API are different.In this case the module could be replaced with esp32 replacement module as they are compatible with most of tesy water heaters, even if not comming with WiFi from the factory.
 
 Tested with:
 
 - [Tesy Modeco Cloud GCV 150 47 24D C22 ECW](https://tesy.com/products/electric-water-heaters/modeco-series/modeco-cloud/?product=gcv-1504724d-c22-ecw)
 
+
+
 ## Highlights
+This intergation allows you to change modes of the water heater ass well as controling the temperature setpoint in manual mode(defined as Performance in HA). 
+
+Also energy counter is working. It uses long term counter from the device that has the seconds the heater/s was/ware on. In order for this to work propperly you need to enter your heater power rating in the setup dialog. This information could be found on the device's label. For double tank devices this is read from the device and leaving it as zero is recommended.
+
+This integration exposes boost mode of the heaters as a switch. It can be switched on and off, but in order to work the heater should on. 
+
+Temperature setpoint is only used in manual(PERFORMANCE) mode. In any other modes it is ignored. If setpoint is manually changed operation mode will jump to performance in case the heater is powered on.
+
 
 ### Have the heater device in HA
 
@@ -21,6 +32,7 @@ Tested with:
 * Click "Install" in the new "Tesy" card in HACS.
 * Install
 * Restart Home Assistant
+* Click add Integration and choose Tesy as integration and put your IP, power rating as prompted.
 
 ### Manual Installation (not recommended)
 * Copy the entire `custom_components/tesy/` directory to your server's `<config>/custom_components` directory

--- a/custom_components/tesy/__init__.py
+++ b/custom_components/tesy/__init__.py
@@ -13,7 +13,12 @@ from .const import (
     DOMAIN,
 )
 
-PLATFORMS = [Platform.WATER_HEATER]
+PLATFORMS: list[Platform] = [
+    Platform.WATER_HEATER,
+    Platform.SENSOR,
+    Platform.SWITCH,
+
+]
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/tesy/config_flow.py
+++ b/custom_components/tesy/config_flow.py
@@ -15,6 +15,10 @@ from .const import (
     ATTR_MAC,
     DOMAIN,
     IP_ADDRESS,
+    HEATER_POWER,
+    ATTR_DEVICE_ID,
+    TESY_DEVICE_TYPES,
+
 )
 from .coordinator import TesyCoordinator
 
@@ -23,6 +27,7 @@ _LOGGER = logging.getLogger(__name__)
 USER_SCHEMA = vol.Schema(
     {
         vol.Required(IP_ADDRESS): cv.string,
+        vol.Required(HEATER_POWER): cv.positive_int,
     }
 )
 
@@ -36,7 +41,14 @@ async def validate_input(hass: HomeAssistant, data: dict) -> dict[str, Any]:
     coordinator = TesyCoordinator(data, hass)
     result = await coordinator.async_validate_input()
 
-    return {"title": "Tesy", "unique_id": result[ATTR_MAC]}
+    title="Tesy"
+
+    if ATTR_DEVICE_ID in result and result[ATTR_DEVICE_ID] in TESY_DEVICE_TYPES:
+        title=TESY_DEVICE_TYPES[result[ATTR_DEVICE_ID]]["name"]
+
+    
+
+    return {"title": title, "unique_id": result[ATTR_MAC]}
 
 
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
@@ -59,7 +71,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             await self.async_set_unique_id(info["unique_id"])
             self._abort_if_unique_id_configured()
 
-            return self.async_create_entry(title=info["title"], data=user_input)
+            return self.async_create_entry(title=info["title"],  data=user_input)
         except ConnectionError:
             errors["base"] = "cannot_connect"
         except AbortFlow as abort_flow_error:

--- a/custom_components/tesy/const.py
+++ b/custom_components/tesy/const.py
@@ -6,12 +6,115 @@ HTTP_TIMEOUT = 15
 UPDATE_INTERVAL = 30
 
 IP_ADDRESS = CONF_IP_ADDRESS
+HEATER_POWER = "heater_power"
+
 
 ATTR_API = "api"
-ATTR_CURRENT_TEMP = "tmpC"
-ATTR_IS_HEATING = "ht"
-ATTR_MAC = "MAC"
-ATTR_MODE = "mode"
-ATTR_POWER = "pwr"
+
+#Current software version
 ATTR_SOFTWARE = "wsw"
+
+#Mac address of the device
+ATTR_MAC = "MAC"
+
+"""Id of the thermocontroller, 
+2000 - ModEco With display
+2002 - BelliSlimo, only support showers 0-4(maximum depends on size and position)
+2003 - BiLight Smart
+2004 - Modeco with bar graph and only two buttons
+2005 - BeliSlimo Lite, only support showers 0-4(maximum depends on size and position)
+"""
+ATTR_DEVICE_ID = "id"
+
+#If currently the heater is heating at che moment
+ATTR_IS_HEATING = "ht"
+
+
+#Current temperature measured. Current showers on Belislimo.
+ATTR_CURRENT_TEMP = "tmpC"
+
+#Target temperature in manual mode, target showers on Belislimo. Integer value in both cases.
 ATTR_TARGET_TEMP = "tmpT"
+
+#READ-ONLY Target temperature that the controller is using depending on mode. If not on manual it will differ from tmpT.
+ATTR_CURRENT_TARGET_TEMP = "tmpR"
+
+"""
+Current Operating mode, depending on the device. P1 and P2 heat up in advance so you have the target at the specified time. P3 is like normal thermostat. 
+0     	manual
+1		P1
+2		P2
+3		P3 
+4		ECO
+5		ECO Confort
+6		ECO Night
+"""
+
+TESY_MODE_P1 = "P1"
+TESY_MODE_P2 = "P2"
+TESY_MODE_P3 = "P3"
+TESY_MODE_EC2 = "EC2"
+TESY_MODE_EC3 = "EC3"
+
+ATTR_MODE = "mode"
+
+#Standby flag, 0 - Off(Antifreeze), 1 -On. If device is off and plugged in will prevent the water from freezing event if off.
+ATTR_POWER = "pwr"
+
+#Boost flag 1 - Active, 0 - Inactive. If set Heater will heat once to max, hold there for some time and clear the flag.
+ATTR_BOOST = "bst"
+
+#Long time counter, counting seconds the heater was operetional. On double tank devices there are  two counters separated by ";" for both heaters. 
+#There is also pwc_u, it can be reset from UI and holds the last reset timestamp
+ATTR_LONG_COUNTER = "pwc_t"
+
+#RSSI
+ATTR_RSSI = "wdBm"
+
+
+ATTR_MAX_SHOWERS = "tmpMX"
+
+
+ATTR_PARAMETERS = "parNF" 
+
+"""
+some devices have additional parameters:
+"extr" - Base64 and url encoded Json, typically containing custom name if renaimed from UI in the CLoud
+"lck" - chield lock. 1- Locked, 0-Unlocked
+"cdt" - count down timer untill target is reached
+"tmpMX" - maximum showers could be set on the device, depends on the leters of the heater, and horisontal/vertical position
+"psn" - Position, vertical/horisontal
+"wup" - Uptime in seconds since last bootup
+"parNF" - Some additionnal parameters like volume and power of heaters on doubletank devices
+
+"""
+TESY_DEVICE_TYPES = {
+    "2000":{
+        "name" : "ModEco",
+        "min_setpoint":15,
+        "max_setpoint":75,
+    },
+    "2002":{
+        "name" : "BeliSlimo",
+        "min_setpoint":0,
+        "max_setpoint":4,
+        "use_showers": True
+    },
+    "2003":{
+        "name" : "BiLight Smart",
+        "min_setpoint":15,
+        "max_setpoint":75,
+    },
+    "2004":{
+        "name" : "ModEco 2",
+        "min_setpoint":15,
+        "max_setpoint":75,
+    },
+    "2005":{
+        "name" : "BelliSlimo Lite",
+        "min_setpoint":0,
+        "max_setpoint":4,
+        "use_showers": True
+
+    }
+}

--- a/custom_components/tesy/coordinator.py
+++ b/custom_components/tesy/coordinator.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 from datetime import timedelta
-import logging
 from typing import Any
 
 from homeassistant.core import HomeAssistant
@@ -14,9 +13,8 @@ from .const import (
     DOMAIN,
     UPDATE_INTERVAL,
 )
-
+import logging
 _LOGGER = logging.getLogger(__name__)
-
 
 class TesyCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     """Tesy Coordinator class."""
@@ -42,7 +40,30 @@ class TesyCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     async def async_validate_input(self) -> None:
         """Validate Tesy component."""
         return await self.hass.async_add_executor_job(self._validate)
+    #Async update Data    
+    async def _async_update_data(self) -> dict[str, Any]:
+        """Get new sensor data for Tesy component."""
+        return await self.hass.async_add_executor_job(self._get_data)
+    
 
+    #Set target temperature in manual mode
+    async def async_set_target_temperature(self, val: int) -> None:
+        """Set target temperature for Tesy component."""
+        return await self.hass.async_add_executor_job(self._client.set_target_temperature, val)
+    #Turn power ON/OFF
+    async def async_set_power(self, val: str) -> None:
+        """Set power for Tesy component."""
+        return await self.hass.async_add_executor_job(self._client.set_power, val)
+    #Turn boost ON/OFF
+    async def async_set_boost(self, val: str) -> None:
+        """Set boost for Tesy component."""
+        return await self.hass.async_add_executor_job(self._client.set_boost, val)
+    #Turn operation mode
+    async def async_set_operation_mode(self, val: str) -> None:
+        """Set mode for Tesy component."""
+        return await self.hass.async_add_executor_job(self._client.set_operation_mode, val)
+    
+    
     def _get_data(self) -> dict[str, Any]:
         """Get new sensor data using Tesy API."""
         try:
@@ -50,22 +71,6 @@ class TesyCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         except ConnectionError as http_error:
             raise UpdateFailed from http_error
 
-    async def _async_update_data(self) -> dict[str, Any]:
-        """Get new sensor data for Tesy component."""
-        return await self.hass.async_add_executor_job(self._get_data)
-
-    def _set_target_temperature(self, val: int) -> None:
-        """Set target temperature using Tesy API."""
-        return self._client.set_target_temperature(val)
-
-    async def async_set_target_temperature(self, val: int) -> None:
-        """Set target temperature for Tesy component."""
-        return await self.hass.async_add_executor_job(self._set_target_temperature, val)
-
-    def _set_power(self, val: str) -> None:
-        """Set target temperature using Tesy API."""
-        return self._client.set_power(val)
-
-    async def async_set_power(self, val: str) -> None:
-        """Set target temperature for Tesy component."""
-        return await self.hass.async_add_executor_job(self._set_power, val)
+    def get_config_power(self) -> int:
+        return self._client._heater_power
+        

--- a/custom_components/tesy/entity.py
+++ b/custom_components/tesy/entity.py
@@ -8,12 +8,18 @@ from homeassistant.helpers.entity import EntityDescription
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import (
+    TESY_DEVICE_TYPES,
+    ATTR_DEVICE_ID,
     ATTR_MAC,
+    ATTR_BOOST,
     ATTR_SOFTWARE,
     DOMAIN,
+    ATTR_API,
 )
 from .coordinator import TesyCoordinator
 
+import logging
+_LOGGER = logging.getLogger(__name__)
 
 class TesyEntity(CoordinatorEntity[TesyCoordinator]):
     """Defines a base Tesy entity."""
@@ -44,6 +50,10 @@ class TesyEntity(CoordinatorEntity[TesyCoordinator]):
     @property
     def device_info(self) -> DeviceInfo:
         """Return device information about this Tesy device."""
+        device_model="Generic"
+        if self.coordinator.data[ATTR_DEVICE_ID] in TESY_DEVICE_TYPES:
+            device_model=TESY_DEVICE_TYPES[self.coordinator.data[ATTR_DEVICE_ID]]["name"]
+
         return DeviceInfo(
             identifiers={
                 (
@@ -52,5 +62,41 @@ class TesyEntity(CoordinatorEntity[TesyCoordinator]):
                 )
             },
             manufacturer="Tesy",
+            model=device_model,
             sw_version=self.coordinator.data[ATTR_SOFTWARE],
         )
+
+    @property
+    def is_boost_mode_on(self):
+        """Return true if boost mode is on."""
+        if ATTR_BOOST in self.coordinator.data and self.coordinator.data[ATTR_BOOST]=="1":
+            return True
+        return False
+
+    async def async_turn_boost_mode_on(self, **kwargs):
+        """Turn on boost mode."""
+        #if self.coordinator.data[ATTR_POWER]=="0":
+        #    await self.coordinator.async_set_power("1")
+
+        if self.coordinator.data[ATTR_BOOST]=="0":
+            response = await self.coordinator.async_set_boost("1")
+            await self.partially_update_data_from_api(response,ATTR_BOOST)
+        
+        #await self.coordinator.async_request_refresh()
+
+    async def async_turn_boost_mode_off(self, **kwargs):
+        """Turn off boost mode."""
+        if self.coordinator.data[ATTR_BOOST]=="1":
+            response = await self.coordinator.async_set_boost("0")
+            await self.partially_update_data_from_api(response,ATTR_BOOST)
+        #await self.coordinator.async_request_refresh()
+
+    async def partially_update_data_from_api(self,response,key):
+        old_data=self.coordinator.data
+        if ATTR_API in response and response[ATTR_API]=="OK" and  key in response:
+            old_data[key]=response[key]
+            self.coordinator.async_set_updated_data(old_data)
+            _LOGGER.debug("Partial update: setting %s to %s",key, response[key])
+    
+
+

--- a/custom_components/tesy/sensor.py
+++ b/custom_components/tesy/sensor.py
@@ -1,0 +1,116 @@
+"""Tesy sensor component."""
+from __future__ import annotations
+
+from homeassistant.components.sensor import (
+    SensorEntity,
+    SensorDeviceClass,
+    SensorStateClass,
+    SensorEntityDescription,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import UnitOfEnergy
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .entity import TesyEntity
+from .const import (
+    ATTR_PARAMETERS,
+    DOMAIN,
+    ATTR_LONG_COUNTER,
+)
+from .coordinator import TesyCoordinator
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Initialize Tesy devices from config entry."""
+
+    coordinator = hass.data[DOMAIN][entry.entry_id]
+    async_add_entities([TesySensor(
+        hass, 
+        coordinator, 
+        entry, 
+        SensorEntityDescription(
+            key="energy_consumed",
+            name="Energy Consumed",
+            device_class=SensorDeviceClass.ENERGY,
+            state_class=SensorStateClass.TOTAL_INCREASING,
+            native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+            icon="mdi:lightning-bolt",
+        ),
+        0.01,
+        None,
+    )])
+
+class TesySensor(TesyEntity, SensorEntity):
+    """Represents a sensor for an Tesy water heater controller."""
+
+    _attr_has_entity_name = True
+    _attr_should_poll = True
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        coordinator: TesyCoordinator,
+        entry: ConfigEntry,
+        description: SensorEntityDescription,
+        suggested_precision: int | None,
+        options: list | None,
+    ) -> None:
+        """Initialize the sensor."""
+        super().__init__(hass, coordinator, entry, description)
+
+        self.description: description
+        self._attr_name = description.name
+ 
+        if description.device_class is not None:
+            self._attr_device_class = description.device_class
+
+        if description.state_class is not None:
+            self._attr_state_class = description.state_class
+
+        if description.native_unit_of_measurement is not None:
+            self._attr_native_unit_of_measurement = (
+                description.native_unit_of_measurement
+            )
+
+        if description.icon is not None:
+            self._attr_icon = description.icon
+
+        if suggested_precision is not None:
+            self._attr_suggested_display_precision = suggested_precision
+
+        if options is not None:
+            self._attr_options = options
+
+    @property
+    def native_value(self):
+        """Return the state of the sensor."""
+        #Prevent crashes if energy counter is missing
+        if ATTR_LONG_COUNTER not in self.coordinator.data:
+            return 0
+        
+        
+        if ";" not in self.coordinator.data[ATTR_LONG_COUNTER]:
+            #For fingle tank heaters, we need to have power walue configured
+            configured_power=self.coordinator.get_config_power()
+            energy_kwh=(int(self.coordinator.data[ATTR_LONG_COUNTER])*configured_power)/3600.0
+            return energy_kwh
+        else:
+            #Prevent crashes if Additional parameters are missing
+            if ATTR_PARAMETERS not in self.coordinator.data:
+                return 0
+            
+            power_dict=self.coordinator.data[ATTR_LONG_COUNTER].split(";")
+            pNF=self.coordinator.data[ATTR_PARAMETERS]
+            watt1 = int(pNF[38 + 0 * 2:40 + 0 * 2], 16) * 20
+            watt2 = int(pNF[38 + 1 * 2:40 + 1 * 2], 16) * 20
+            tmp_kwh1=(int(power_dict[0])*watt1)/3600.0
+            tmp_kwh2=(int(power_dict[1])*watt2)/3600.0
+
+            return tmp_kwh1+tmp_kwh2
+        
+
+    

--- a/custom_components/tesy/switch.py
+++ b/custom_components/tesy/switch.py
@@ -1,0 +1,79 @@
+"""Tesy switch component."""
+from __future__ import annotations
+
+from homeassistant.components.switch import (
+    SwitchEntity,
+    SwitchDeviceClass,
+    SwitchEntityDescription,
+)
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .entity import TesyEntity
+from .const import DOMAIN
+from .coordinator import TesyCoordinator
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Initialize Tesy devices from config entry."""
+
+    coordinator = hass.data[DOMAIN][entry.entry_id]
+
+    async_add_entities([TesySwitch(
+        hass, 
+        coordinator, 
+        entry, 
+        SwitchEntityDescription(
+            key="boost",
+            name="Boost",
+            icon="mdi:rocket-launch-outline",
+            device_class=SwitchDeviceClass.SWITCH,
+        ),
+        lambda entity: entity.is_boost_mode_on,
+        lambda entity: entity.async_turn_boost_mode_on,
+        lambda entity: entity.async_turn_boost_mode_off,
+    )])
+
+
+class TesySwitch(TesyEntity, SwitchEntity):
+    """Represents a toggle switch for an Tesy device."""
+
+    _attr_has_entity_name = True
+    _attr_should_poll = True
+
+    def __init__(
+        self,
+        hass,
+        coordinator: TesyCoordinator,
+        entry: ConfigEntry,
+        description: SwitchEntityDescription,
+        is_on_func,
+        async_turn_on_func,
+        async_turn_off_func,
+    ) -> None:
+        """Initialize the switch."""
+        super().__init__(hass, coordinator, entry,description)
+        self.entity_description = description
+        self._attr_name = description.name
+        self._is_on_func = is_on_func
+        self._async_turn_on_func = async_turn_on_func
+        self._async_turn_off_func = async_turn_off_func
+
+    @property
+    def is_on(self):
+        """Return true if the switch is on."""
+        return self._is_on_func(self)
+
+    async def async_turn_on(self, **kwargs):
+        """Turn the switch on."""
+        return await self._async_turn_on_func(self)()
+
+    async def async_turn_off(self, **kwargs):
+        """Turn the switch off."""
+        return await self._async_turn_off_func(self)()

--- a/custom_components/tesy/tesy.py
+++ b/custom_components/tesy/tesy.py
@@ -10,8 +10,12 @@ import requests
 from .const import (
     ATTR_POWER,
     ATTR_TARGET_TEMP,
+    ATTR_BOOST,
+    ATTR_MODE,
     HTTP_TIMEOUT,
     IP_ADDRESS,
+    HEATER_POWER,
+
 )
 
 
@@ -24,6 +28,10 @@ class Tesy:
     def __init__(self, data: dict[str, Any]) -> None:
         """Init Tesy."""
         self._ip_address = data[IP_ADDRESS]
+        
+        self._heater_power = 2400
+        if HEATER_POWER in data:
+            self._heater_power = data[HEATER_POWER]
 
     def get_data(self) -> dict[str, Any]:
         """Get data for Tesy component."""
@@ -31,13 +39,19 @@ class Tesy:
 
     def set_target_temperature(self, val: int) -> bool:
         """Set target temperature for Tesy component."""
-        self._get_request(name=ATTR_TARGET_TEMP, set=val).json()
-        return True
+        return self._get_request(name=ATTR_TARGET_TEMP, set=val).json()
 
     def set_power(self, val: str) -> bool:
         """Set power for Tesy component."""
-        self._get_request(name=ATTR_POWER, set=val).json()
-        return True
+        return self._get_request(name=ATTR_POWER, set=val).json()
+    
+    def set_boost(self, val: str) -> bool:
+        """Set boost for Tesy component."""
+        return self._get_request(name=ATTR_BOOST, set=val).json()
+    
+    def set_operation_mode(self, val: str) -> bool:
+        """Set boost for Tesy component."""
+        return self._get_request(name=ATTR_MODE, set=val).json()
 
     def _get_request(self, **kwargs) -> requests.Response:
         """Make GET request to the Tesy API."""
@@ -58,3 +72,5 @@ class Tesy:
             raise ConnectionError from connection_error
         except requests.exceptions.HTTPError as http_error:
             raise ConnectionError from http_error
+
+

--- a/custom_components/tesy/water_heater.py
+++ b/custom_components/tesy/water_heater.py
@@ -1,5 +1,6 @@
 """Tesy water heater component."""
 from typing import Any
+from custom_components.tesy.coordinator import TesyCoordinator
 
 from homeassistant.components.water_heater import (
     STATE_ECO,
@@ -19,23 +20,29 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import (
+    TESY_DEVICE_TYPES,
     ATTR_CURRENT_TEMP,
+    ATTR_DEVICE_ID,
+    ATTR_MAX_SHOWERS,
     ATTR_IS_HEATING,
     ATTR_MODE,
     ATTR_POWER,
     ATTR_TARGET_TEMP,
     DOMAIN,
+    TESY_MODE_P1,
+    TESY_MODE_P2,
+    TESY_MODE_P3,
+    TESY_MODE_EC2,
+    TESY_MODE_EC3,
 )
+
 from .entity import TesyEntity
 
-# NOTE: more modes not implemented
-OPERATION_LIST = [STATE_OFF, STATE_PERFORMANCE]
+import logging
+_LOGGER = logging.getLogger(__name__)
+_LOGGER.setLevel(logging.DEBUG)
 
-DESCRIPTION = WaterHeaterEntityEntityDescription(
-    key="water_heater",
-    translation_key="heater",
-)
-
+OPERATION_LIST = [STATE_OFF,STATE_PERFORMANCE,TESY_MODE_P1,TESY_MODE_P2,TESY_MODE_P3,STATE_ECO,TESY_MODE_EC2,TESY_MODE_EC3]
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -44,7 +51,15 @@ async def async_setup_entry(
 ) -> None:
     """Create Tesy water heater in HASS."""
     coordinator = hass.data[DOMAIN][entry.entry_id]
-    async_add_entities([TesyWaterHeater(hass, coordinator, entry, DESCRIPTION)])
+    async_add_entities([TesyWaterHeater(
+        hass, 
+        coordinator, 
+        entry, 
+        WaterHeaterEntityEntityDescription(
+            key="water_heater",
+            translation_key="heater",
+        )
+    )])
 
 
 class TesyWaterHeater(TesyEntity, WaterHeaterEntity):
@@ -58,8 +73,23 @@ class TesyWaterHeater(TesyEntity, WaterHeaterEntity):
         | WaterHeaterEntityFeature.OPERATION_MODE
         | WaterHeaterEntityFeature.ON_OFF
     )
-    _attr_min_temp = 16
-    _attr_max_temp = 75
+
+
+    def __init__(self, hass: HomeAssistant, coordinator: TesyCoordinator, entry: ConfigEntry, description: Any) -> None:
+        super().__init__(hass, coordinator, entry, description)
+
+        #Default values
+        self._attr_min_temp = 15
+        self._attr_max_temp = 75
+
+        if self.coordinator.data[ATTR_DEVICE_ID] in TESY_DEVICE_TYPES:
+            self._attr_min_temp=TESY_DEVICE_TYPES[self.coordinator.data[ATTR_DEVICE_ID]]["min_setpoint"]
+            self._attr_max_temp=TESY_DEVICE_TYPES[self.coordinator.data[ATTR_DEVICE_ID]]["max_setpoint"]
+
+            #if heater only supports showers, get its maximum depending on model, position
+            if "use_showers" in  TESY_DEVICE_TYPES[self.coordinator.data[ATTR_DEVICE_ID]] and TESY_DEVICE_TYPES[self.coordinator.data[ATTR_DEVICE_ID]]["use_showers"] == True:
+                 tmp_max=self.coordinator.data[ATTR_MAX_SHOWERS]
+                 self._attr_max_temp=int(tmp_max) if tmp_max.isdecimal() else self._attr_max_temp
 
     @property
     def current_temperature(self):
@@ -69,51 +99,113 @@ class TesyWaterHeater(TesyEntity, WaterHeaterEntity):
     @property
     def current_operation(self):
         """Return current operation."""
-        state = STATE_OFF
+
+        if ATTR_POWER not in self.coordinator.data or ATTR_MODE not in self.coordinator.data:
+            return STATE_OFF
+        
+        #if powered off
+        if self.coordinator.data[ATTR_POWER] != "1":
+            return STATE_OFF
+
         mode = self.coordinator.data[ATTR_MODE]
 
-        if self.coordinator.data[ATTR_POWER] != "1":
-            return state
-
         if mode == "0":
-            state = STATE_PERFORMANCE
+            return STATE_PERFORMANCE
         if mode == "1":
-            state = "Program"
+            return TESY_MODE_P1
+        if mode == "2":
+            return TESY_MODE_P2
         if mode == "3":
-            state = STATE_ECO
+            return TESY_MODE_P3
+        if mode == "4":
+            return STATE_ECO
+        if mode == "5":
+            return TESY_MODE_EC2
+        if mode == "6":
+            return TESY_MODE_EC3
 
-        return state
+        #Handle unknown state
+        return STATE_OFF
 
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set new target temperature."""
-        await self.coordinator.async_set_target_temperature(
+         #Just in case if power is missing from json, prevent crashes
+        if  ATTR_POWER not in self.coordinator.data:
+            return
+        
+        if self.coordinator.data[ATTR_POWER]=="1":
+            if self.coordinator.data[ATTR_MODE] != STATE_PERFORMANCE:
+                response = await self.coordinator.async_set_operation_mode("0")
+                await self.partially_update_data_from_api(response,ATTR_MODE)
+
+        response = await self.coordinator.async_set_target_temperature(
             kwargs.get(ATTR_TEMPERATURE)
         )
-        await self.coordinator.async_request_refresh()
+        await self.partially_update_data_from_api(response,ATTR_TARGET_TEMP)
+        #await self.coordinator.async_request_refresh()
 
     async def async_set_operation_mode(self, operation_mode: str) -> None:
         """Set new target operation mode."""
-        if operation_mode == STATE_PERFORMANCE:
-            await self.turn_on()
+
+        #Just in case if power is missing from json, prevent crashes
+        if  ATTR_POWER not in self.coordinator.data:
+            return
+        
+        
+        if  operation_mode == STATE_OFF and self.coordinator.data[ATTR_POWER]=="1":
+            response = await self.coordinator.async_set_power("0")
+            await self.partially_update_data_from_api(response,ATTR_POWER)
         else:
-            await self.turn_off()
+            if self.coordinator.data[ATTR_POWER]=="0":
+                response = await self.coordinator.async_set_power("1")
+                await self.partially_update_data_from_api(response,ATTR_POWER)
+
+            if operation_mode == STATE_PERFORMANCE:
+                new_mode="0"
+                #await self.coordinator.async_set_operation_mode("0")
+            if  operation_mode == TESY_MODE_P1:
+                new_mode="1"
+                #await self.coordinator.async_set_operation_mode("1")
+            if  operation_mode == TESY_MODE_P2:
+                new_mode="2"
+                #await self.coordinator.async_set_operation_mode("2")
+            if  operation_mode == TESY_MODE_P3:
+                new_mode="3"
+                #await self.coordinator.async_set_operation_mode("3")
+            if  operation_mode == STATE_ECO:
+                new_mode="4"
+                #await self.coordinator.async_set_operation_mode("4")
+            if  operation_mode == TESY_MODE_EC2:
+                new_mode="4"
+                #await self.coordinator.async_set_operation_mode("5")
+            if  operation_mode == TESY_MODE_EC3:
+                new_mode="6"
+                #await self.coordinator.async_set_operation_mode("6")
+
+            response = await self.coordinator.async_set_operation_mode(new_mode)
+            await self.partially_update_data_from_api(response,ATTR_MODE)
+
+        #await self.coordinator.async_request_refresh()
 
     async def turn_on(self, **_kwargs: Any) -> None:
         """Turn on water heater."""
-        await self.coordinator.async_set_power("1")
-        await self.coordinator.async_request_refresh()
+        response = await self.coordinator.async_set_power("1")
+        await self.partially_update_data_from_api(response,ATTR_POWER)
+        #await self.coordinator.async_request_refresh()
 
     async def turn_off(self, **_kwargs: Any) -> None:
         """Turn off water heater."""
-        await self.coordinator.async_set_power("0")
-        await self.coordinator.async_request_refresh()
+        response = await self.coordinator.async_set_power("0")
+        await self.partially_update_data_from_api(response,ATTR_POWER)
+        #await self.coordinator.async_request_refresh()
 
     @property
     def target_temperature(self):
         """Return the target temperature."""
+        #Return setpoint do 
         return float(self.coordinator.data[ATTR_TARGET_TEMP])
 
     @property
     def extra_state_attributes(self) -> dict[str, str] | None:
         """Return the state attributes."""
-        return {"is_heating": self.coordinator.data[ATTR_IS_HEATING] == "1"}
+        return {"is_heating": ATTR_IS_HEATING in self.coordinator.data and self.coordinator.data[ATTR_IS_HEATING] == "1", "target_temp_step":1}


### PR DESCRIPTION
Update the extension to:
Properly handle device ID and diferentiate different devices . Support P1,P2,P3 ECO, EC2, EC3 modes of the device Add BOOST switch
Add energy counter fro easy integration into energy dashboard Properly handle reponses of the api and if api call is successfull use its result for partial update in coordinator instead of forcing full update.  Added way to configure heater power rating in setup. NOTE it is not needed for double tank devices as they know what watage heater they have. 
Updated documentation