### PR TITLE
Added temperature sensor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -157,4 +157,4 @@ cython_debug/
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
+.idea/


### PR DESCRIPTION
This PR adds current boiler temperature as a separate sensor. Useful for easier graph access and necessary for automations that rely on the current temperature. For example, I'm intending to "overheat" the boiler with solar energy, but only if the temperature is not high enough already and there are no better ways to spend the excess.