### PR TITLE
Added support for Tesy Space Heater 'Tesy space heater CN04 200'

### DIFF
--- a/custom_components/tesy/tesy_oldapi.py
+++ b/custom_components/tesy/tesy_oldapi.py
@@ -54,7 +54,6 @@ class TesyOldApi:
             }
         )
 
-
         _LOGGER.debug(f"converted API: {str(o)}")
         return o
 
@@ -79,6 +78,7 @@ class TesyOldApi:
     def set_operation_mode(self, val: str) -> bool:
         """Set mode for Tesy component."""
         return self._get_request("modeSW", mode=int(val) + 1).json()
+
     def _coerce_mode(self, mode: Any) -> str:
         """Convert mode reported by the old API into the numeric string the integration expects."""
         if mode is None:


### PR DESCRIPTION
I was trying to connect my Space Heater - Tesy CN04 200. To home assistant but it was giving me errors. 

This is the product
https://tesy.bg/produkti/arhiv/cn-04-200-eis
<img width="350" height="350" alt="TESY-Conveco-CN04--EIS" src="https://github.com/user-attachments/assets/30499043-5466-4371-b517-7714a03bf672" />


The errors I got was: 
```
2026-01-29 04:12:00.277 ERROR (MainThread) [custom_components.tesy.config_flow] Unexpected exception invalid literal for int() with base 10: 'Manual'
Traceback (most recent call last):
  File "/config/custom_components/tesy/config_flow.py", line 69, in async_step_user
    info = await validate_input(self.hass, user_input)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/config/custom_components/tesy/config_flow.py", line 44, in validate_input
    result = await coordinator.async_validate_input()
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/config/custom_components/tesy/coordinator.py", line 50, in async_validate_input
    return await self.hass.async_add_executor_job(self._validate)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.13/concurrent/futures/thread.py", line 59, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/config/custom_components/tesy/coordinator.py", line 43, in _validate
    result = self._client.get_data()
  File "/config/custom_components/tesy/tesy_oldapi.py", line 30, in get_data
    return self.convertApi(
           ~~~~~~~~~~~~~~~^
        {
        ^
    ...<2 lines>...
        }
        ^
    )
    ^
  File "/config/custom_components/tesy/tesy_oldapi.py", line 47, in convertApi
    ATTR_MODE: str(int(data["status"]["mode"]) - 1),
                   ~~~^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: invalid literal for int() with base 10: 'Manual'
```


I checked it's API and it was indeed returning a mode like text. This is what the API response looks like: 
http://192.168.0.150/status
```
{"heater_state":"READY","mode":"Manual","power_sw":"on","gradus":"23.0","watts":"1000","ref_gradus":"15","dtime":"720","tz":"EET","antifrost_enable":"1","winButt":"on","window":"close","lockB":"off","tempcor_enable":"1","adaptive_start_enable":"1","date":"2026-01-29 04:21"}
```

here is another response when it is heating: 
```
{"heater_state":"HEATING","mode":"Manual","power_sw":"on","gradus":"22.5","watts":"1000","ref_gradus":"23","dtime":"720","tz":"EET","antifrost_enable":"1","winButt":"on","window":"close","lockB":"off","tempcor_enable":"1","adaptive_start_enable":"1","date":"2026-01-29 04:43"}
```

I made the changes you see in the commit and I was able to successfully connect and see it correctly in Home Assistant 
<img width="511" height="292" alt="image" src="https://github.com/user-attachments/assets/9b3c02f9-50e0-47a6-9bb2-f81f0876cbd5" />


The Boost does not work. I get: 
```
2026-01-29 04:32:28.898 ERROR (MainThread) [homeassistant.components.websocket_api.http.connection] [123325642329600] Unexpected exception
Traceback (most recent call last):
  File "/config/custom_components/tesy/tesy_oldapi.py", line 120, in _get_request
    r.raise_for_status()
    ~~~~~~~~~~~~~~~~~~^^
  File "/usr/local/lib/python3.13/site-packages/requests/models.py", line 1026, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 404 Client Error: File not found for url: http://192.168.0.150/boostSW?mode=1

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/components/websocket_api/commands.py", line 278, in handle_call_service
    response = await hass.services.async_call(
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ...<7 lines>...
    )
    ^
  File "/usr/src/homeassistant/homeassistant/core.py", line 2819, in async_call
    response_data = await coro
                    ^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/core.py", line 2862, in _execute_service
    return await target(service_call)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/helpers/service.py", line 832, in entity_service_call
    single_response = await _handle_entity_call(
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^
        hass, entity, func, data, call.context
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/usr/src/homeassistant/homeassistant/helpers/service.py", line 904, in _handle_entity_call
    result = await task
             ^^^^^^^^^^
  File "/config/custom_components/tesy/switch.py", line 80, in async_turn_on
    return await self._async_turn_on_func(self)()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/config/custom_components/tesy/entity.py", line 88, in async_turn_boost_mode_on
    response = await self.coordinator.async_set_boost("1")
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/config/custom_components/tesy/coordinator.py", line 72, in async_set_boost
    return await self.hass.async_add_executor_job(self._client.set_boost, val)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.13/concurrent/futures/thread.py", line 59, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/config/custom_components/tesy/tesy_oldapi.py", line 77, in set_boost
    return self._get_request("boostSW", mode=val).json()
           ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^
  File "/config/custom_components/tesy/tesy_oldapi.py", line 130, in _get_request
    raise ConnectionError from http_error
ConnectionError

```
But I think this is expected.
I don't think this heater have a boost option. 

## My changes
If the mode is number - works like before
If mode is string -> maps it to number;

The number mapping - I'm not sure if correct at all, feel free to change it

I've only seen **Manual** on my device and I'm not familiar with the other options. 

I just wanted to share the changes I made to work with my device if helpful 

Cheers.

Oh and and `http://192.168.0.150/devstat` has `"devid":"1006-34008a32132b FW20.8"`

