### PR TITLE
Fix: seed energy from pwc_t on startup, optimistic target temp update

### DIFF
--- a/custom_components/tesy/sensor.py
+++ b/custom_components/tesy/sensor.py
@@ -258,6 +258,17 @@ class TesyEnergySensor(TesySensor, RestoreSensor):
 
         if not is_double_tank and self._last_update is not None:
             elapsed = (now - self._last_update).total_seconds()
+
+            # Seed from firmware counter if no restored value (fresh install / RestoreSensor failed)
+            if self._energy_kwh == 0:
+                pwc_t = data.get(ATTR_LONG_COUNTER, "")
+                if pwc_t:
+                    try:
+                        power_w = self.coordinator.get_config_power()
+                        self._energy_kwh = (int(pwc_t) * power_w) / 3_600_000.0
+                    except (TypeError, ValueError):
+                        pass
+
             if data.get(ATTR_IS_HEATING) == "1":
                 power_w = self.coordinator.get_config_power()
                 self._energy_kwh += (power_w * elapsed) / 3_600_000.0

--- a/custom_components/tesy/water_heater.py
+++ b/custom_components/tesy/water_heater.py
@@ -177,6 +177,11 @@ class TesyWaterHeater(TesyEntity, WaterHeaterEntity):
         await self.partially_update_data_from_api(
             response, ATTR_TARGET_TEMP, ATTR_CURRENT_TARGET_TEMP
         )
+        # Optimistic: in manual mode, tmpR always equals tmpT
+        new_temp = kwargs.get(ATTR_TEMPERATURE)
+        if new_temp is not None:
+            self.coordinator.data[ATTR_CURRENT_TARGET_TEMP] = new_temp
+            self.coordinator.async_set_updated_data(self.coordinator.data)
 
     async def async_set_operation_mode(self, operation_mode: str) -> None:
         """Set new target operation mode."""


### PR DESCRIPTION
## Summary

Two bugfixes for regressions introduced in v1.6.0:

**Fixes #37** — Target Temperature entity now updates instantly when changed via the water heater entity, instead of waiting for the next 30-second poll.

**Fixes #38** — Energy sensor now shows correct historical consumption on fresh install or after RestoreSensor failure, instead of staying at 0.

---

### #37 — Target Temperature delay

In v1.6.0, `target_temperature` was changed to read `tmpR` (the controller's actual target) instead of `tmpT` (the user-set point). This is semantically correct, but `async_set_temperature` only updated `tmpT` in the local cache. Since the API response for `set=tmpT` doesn't include `tmpR`, the entity stayed stale until the next full poll.

Fix: optimistic update of `tmpR` after setting temperature. Since we already force manual mode where `tmpR == tmpT`, this is safe. The next poll overwrites with the real value.

### #38 — Energy sensor shows 0

In v1.6.0, `TesyEnergySensor` was rewritten to accumulate energy in real-time from the `ht` (is-heating) flag instead of reading `pwc_t` directly. On a fresh install (or if RestoreSensor can't restore state), `_energy_kwh` starts at 0 and only increases when the device is currently heating — all historical energy is lost.

This doesn't affect double-tank devices (which still read `pwc_t` directly via the `;` detection).

Fix: seed `_energy_kwh` from the firmware's `pwc_t` counter on the first coordinator update when no restored value exists. Only fires once, then the real-time accumulator takes over.
